### PR TITLE
Avoid errors.ProgrammerError class

### DIFF
--- a/berlekamp_welch.go
+++ b/berlekamp_welch.go
@@ -24,8 +24,6 @@ package infectious
 
 import (
 	"sort"
-
-	"github.com/spacemonkeygo/errors"
 )
 
 // Decode will take a destination buffer (can be nil) and a list of shares
@@ -52,7 +50,7 @@ func (f *FEC) Decode(dst []byte, shares []Share) ([]byte, error) {
 	}
 
 	if len(shares) == 0 {
-		return nil, errors.ProgrammerError.New("must specify at least one share")
+		return nil, Error.New("must specify at least one share")
 	}
 	piece_len := len(shares[0].Data)
 	result_len := piece_len * f.k
@@ -80,7 +78,7 @@ func (f *FEC) decode(shares []Share, output func(Share)) error {
 // mutating the underlying byte slices and reordering the shares
 func (fc *FEC) Correct(shares []Share) error {
 	if len(shares) < fc.k {
-		return errors.ProgrammerError.New("must specify at least the number of required shares")
+		return Error.New("must specify at least the number of required shares")
 	}
 
 	sort.Sort(byNumber(shares))

--- a/gf_alg.go
+++ b/gf_alg.go
@@ -26,8 +26,6 @@ import (
 	"fmt"
 	"strings"
 	"unsafe"
-
-	"github.com/spacemonkeygo/errors"
 )
 
 //
@@ -55,7 +53,7 @@ func (a gfVal) mul(b gfVal) gfVal {
 
 func (a gfVal) div(b gfVal) (gfVal, error) {
 	if b == 0 {
-		return 0, errors.ProgrammerError.New("divide by zero")
+		return 0, Error.New("divide by zero")
 	}
 	if a == 0 {
 		return 0, nil
@@ -73,7 +71,7 @@ func (a gfVal) isZero() bool {
 
 func (a gfVal) inv() (gfVal, error) {
 	if a == 0 {
-		return 0, errors.ProgrammerError.New("invert zero")
+		return 0, Error.New("invert zero")
 	}
 	return gfVal(gf_exp[255-gf_log[a]]), nil
 }
@@ -175,7 +173,7 @@ func (p gfPoly) div(b gfPoly) (q, r gfPoly, err error) {
 		b = b[1:]
 	}
 	if len(b) == 0 {
-		return nil, nil, errors.ProgrammerError.New("divide by zero")
+		return nil, nil, Error.New("divide by zero")
 	}
 
 	// sanitize the base poly as well
@@ -223,7 +221,7 @@ func (p gfPoly) div(b gfPoly) (q, r gfPoly, err error) {
 
 		p = p.add(padded)
 		if !p[0].isZero() {
-			return nil, nil, errors.ProgrammerError.New("alg error: %x", p)
+			return nil, nil, Error.New("alg error: %x", p)
 		}
 		p = p[1:]
 	}


### PR DESCRIPTION
The errors.ProgrammerError class is defined in spacemonkeygo/errors with the LogOnCreation option. This forces the error to be logged with the stack trace at the moment it is created. This might be undesired by apps using the infectious library as it polutes the log output. For example, this happens to me in the build as I have a test suite covering erroneous use cases.

This patch replaces the errors.ProgrammerError class with the already defined Error class in the infectious library.