### PR TITLE
Add CorrectWithResults to allow the caller to see the list of corrupted shares

### DIFF
--- a/berlekamp_welch.go
+++ b/berlekamp_welch.go
@@ -87,7 +87,7 @@ func (fc *FEC) Correct(shares []Share) error {
 // It will also return a list of shares that have been corrupted
 func (fc *FEC) CorrectWithResults(shares []Share) (badShares []Share, err error) {
 	if len(shares) < fc.k {
-		return badShares, Error.New("must specify at least the number of required shares")
+		return nil, Error.New("must specify at least the number of required shares")
 	}
 
 	sort.Sort(byNumber(shares))

--- a/berlekamp_welch.go
+++ b/berlekamp_welch.go
@@ -92,6 +92,7 @@ func (fc *FEC) CorrectWithResults(shares []Share) (badShares []Share, err error)
 	}
 	buf := make([]byte, len(shares[0].Data))
 
+	badShareMap := make(map[int]bool)
 	for i := 0; i < synd.r; i++ {
 		for j := range buf {
 			buf[j] = 0
@@ -110,12 +111,27 @@ func (fc *FEC) CorrectWithResults(shares []Share) (badShares []Share, err error)
 				return nil, err
 			}
 			for _, share := range shares {
+				if share.Data[j] != data[share.Number] && !badShareMap[share.Number] {
+					badShares = append(badShares, share)
+					badShareMap[share.Number] = true
+				}
 				share.Data[j] = data[share.Number]
 			}
 		}
 	}
 
 	return badShares, nil
+}
+
+// makeCopies takes in a slice of Shares and deep copies their data to a new slice
+func makeCopies(originals []Share) (copies []Share) {
+	copies = make([]Share, 0, len(originals))
+	for _, original := range originals {
+		copies = append(copies, Share{
+			Data:   append([]byte{}, original.Data...),
+			Number: original.Number})
+	}
+	return copies
 }
 
 // Correct implements the Berlekamp-Welch algorithm for correcting


### PR DESCRIPTION
Probably needs to be rewritten so that `Correct` does not need to call `CorrectWithResults`.

`CorrectWithResults` makes a deep copy of the shares passed in, runs the correction algorithm, and compares the copied shares with the corrected shares. If it finds a share with altered data, it appends this to the bad shares slice, which is returned at the end.